### PR TITLE
better support for x-www-form-urlencoded POST requests

### DIFF
--- a/Tizzani.QueryStringHelpers/QueryStringSerializer.cs
+++ b/Tizzani.QueryStringHelpers/QueryStringSerializer.cs
@@ -60,12 +60,12 @@ public static class QueryStringSerializer
                 uri = QueryHelpers.AddQueryString(uri, kvp.Key, valueString);            
         }
 
-        return uri;
+        return uri[1..];
     }
 
     public static string Serialize<T>(T obj, string baseUri) where T : class
     {
-        return baseUri + Serialize(obj);
+        return $"{baseUri}?{Serialize(obj)}";
     }
 
     public static T? Deserialize<T>(string uri) where T : class


### PR DESCRIPTION
URL-encoded strings are also useful for constructing the bodies of POST requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST#example

we also wouldn't require the leading `?` when deserializing; the `?`s only purpose is to separate the query string from a URL.