### PR TITLE
exposing `forceReload` and `replace` parameters from NavigationManager

### DIFF
--- a/src/Tizzani.QueryStringSerializer.Blazor/NavigationManagerExtensions.cs
+++ b/src/Tizzani.QueryStringSerializer.Blazor/NavigationManagerExtensions.cs
@@ -4,16 +4,16 @@ namespace Tizzani.QueryStringSerializer.Blazor;
 
 public static class NavigationManagerExtensions
 {
-    public static void NavigateToWithQuery(this NavigationManager navManager, string baseUri, object obj)
+    public static void NavigateToWithQuery(this NavigationManager navManager, string baseUri, object obj, bool forceLoad = false, bool replace = false)
     {
         var uri = QueryStringSerializer.Serialize(obj, baseUri);
-        navManager.NavigateTo(uri);
+        navManager.NavigateTo(uri, forceLoad, replace);
     }
 
-    public static void NavigateToWithQuery(this NavigationManager navManager, string baseUri, object obj, QueryStringSerializerOptions options)
+    public static void NavigateToWithQuery(this NavigationManager navManager, string baseUri, object obj, QueryStringSerializerOptions options, bool forceLoad = false, bool replace = false)
     {
         var uri = QueryStringSerializer.Serialize(obj, baseUri, options);
-        navManager.NavigateTo(uri);
+        navManager.NavigateTo(uri, forceLoad, replace);
     }
 
     public static T? GetQueryObject<T>(this NavigationManager navManager)

--- a/tests/Tizzani.QueryStringSerializer.Tests/QueryStringSerializerTests.cs
+++ b/tests/Tizzani.QueryStringSerializer.Tests/QueryStringSerializerTests.cs
@@ -12,6 +12,7 @@ public class QueryStringSerializerTests
 {
 
     [Theory]
+    [InlineData("?SomeParameter=hello, world!", "hello, world!")]
     [InlineData("SomeParameter=hello, world!", "hello, world!")]
     [InlineData("SomeParameter=hello,+world!", "hello, world!")]
     [InlineData("SomeParameter=hello,%20world!", "hello, world!")]
@@ -38,6 +39,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeParameter=0", 0)]
     [InlineData("SomeParameter=0", 0)]
     [InlineData("SomeParameter=1", 1)]
     [InlineData("SomeParameter=-1", -1)]
@@ -65,6 +67,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeParameter=1&SomeParameter=2&SomeParameter=3", 1, 2, 3)]
     [InlineData("SomeParameter=1&SomeParameter=2&SomeParameter=3", 1, 2, 3)]
     [InlineData("SomeParameter=0&SomeParameter=0&SomeParameter=0", 0, 0, 0)]
     [InlineData("SomeParameter=-1&SomeParameter=1", -1, 1)]
@@ -77,6 +80,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeParameter=1&SomeParameter=2&SomeParameter=3", 1, 2, 3)]
     [InlineData("SomeParameter=1&SomeParameter=2&SomeParameter=3", 1, 2, 3)]
     [InlineData("SomeParameter=0&SomeParameter=0&SomeParameter=0", 0, 0, 0)]
     [InlineData("SomeParameter=-1&SomeParameter=1", -1, 1)]
@@ -89,6 +93,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeParameter=1&SomeParameter=2&SomeParameter=3", 1, 2, 3)]
     [InlineData("SomeParameter=1&SomeParameter=2&SomeParameter=3", 1, 2, 3)]
     [InlineData("SomeParameter=0&SomeParameter=0&SomeParameter=0", 0, 0, 0)]
     [InlineData("SomeParameter=-1&SomeParameter=1", -1, 1)]
@@ -149,6 +154,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeParameter.SomeParameter=1", 1)]
     [InlineData("SomeParameter.SomeParameter=1", 1)]
     [InlineData("SomeParameter.SomeParameter=-1", -1)]
     [InlineData("SomeParameter.SomeParameter=0", 0)]
@@ -185,6 +191,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeString=Anything", "Anything")]
     [InlineData("SomeString=Anything", "Anything")]
     public void Deserialize_CreatesCorrectObject_ForRecords(string queryString, string expectedValue)
     {
@@ -194,6 +201,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeString=Anything", "Anything")]
     [InlineData("SomeString=Anything", "Anything")]
     public void Deserialize_CreatesCorrectObject_ForStructs(string queryString, string expectedValue)
     {
@@ -202,6 +210,7 @@ public class QueryStringSerializerTests
     }
 
     [Theory]
+    [InlineData("?SomeString=Anything", "Anything")]
     [InlineData("SomeString=Anything", "Anything")]
     public void Deserialize_CreatesCorrectObject_ForReadonlyStructs(string queryString, string expectedValue)
     {


### PR DESCRIPTION
also: added unit tests to ensure that we correctly deserialize query strings which are prefixed with a `?`